### PR TITLE
fix: CI 에러

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
       
       - name: build client files
         working-directory: ./client
-        run: npm run build
+        run: CI='' npm run build
 
       - name: zip distributions
         run: zip -r desk-it.zip ./client/build ./server


### PR DESCRIPTION
## 🍟 PR 요약
npm build 고치기 (github action)

## 🍔 Detail 
https://velog.io/@developerjhp/s3-%EB%B0%B0%ED%8F%AC%EC%9E%90%EB%8F%99%ED%99%94-Treating-warnings-as-errors-because-process.env.CI-true.Most-CI-servers-set-it-automatically

## 🍦 기타사항
none
